### PR TITLE
fix(schema): Added quotes to schemas avoiding special char errors

### DIFF
--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -187,7 +187,7 @@ export default class YourDriverClass extends AbstractDriver<Athena, Athena.Types
           childType: ContextValue.TABLE,
         }));
       case ContextValue.TABLE:
-        const tables = await this.rawQuery(`SHOW TABLES IN ${parent.database}`);
+        const tables = await this.rawQuery(`SHOW TABLES IN "${parent.database}"`);
         const views = await this.rawQuery(`SHOW VIEWS IN "${parent.database}"`);
 
         console.log(JSON.stringify({tables, views}))


### PR DESCRIPTION
Currently, when a schema has a `-` char, it breaks on listing its children. using double quotes around schema queries fixes this.