### PR TITLE
add profile support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "debug.onTaskErrors": "debugAnyway",
 }

--- a/connection.schema.json
+++ b/connection.schema.json
@@ -7,23 +7,66 @@
       "type": "string",
       "minLength": 1
     },
-    "accessKeyId": {
-      "title": "Access Key Id",
-      "type": "string",
-      "minLength": 1
-    },
-    "secretAccessKey": {
-      "title": "Secret Access Key",
-      "type": "string",
-      "minLength": 1
-    },
     "region": {
       "title": "AWS Region",
       "type": "string",
       "minLength": 1
+    },
+    "connectionMethod": {
+      "title": "Connect using",
+      "type": "string",
+      "minLength": 1,
+      "enum": ["Profile", "Session Credentials"],
+      "default": "Profile"
+    }
+  },
+  "dependencies": {
+    "connectionMethod": {
+      "oneOf": [
+        {
+          "properties": {
+            "connectionMethod": {
+              "enum": ["Profile"]
+            },
+            "profile": {
+              "title": "AWS Profile",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "workgroup", "profile", "region"
+          ]
+        },
+        {
+          "properties": {
+            "connectionMethod": {
+              "enum": ["Session Credentials"]
+            },
+            "accessKeyId": {
+              "title": "Access Key Id",
+              "type": "string",
+              "minLength": 1
+            },
+            "secretAccessKey": {
+              "title": "Secret Access Key",
+              "type": "string",
+              "minLength": 1
+            },
+            "sessionToken": {
+              "title": "Session Token",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "workgroup", "accessKeyId", "secretAccessKey", "region"
+          ]
+        }
+      ]
     }
   },
   "required": [
-    "workgroup", "accessKeyId", "secretAccessKey", "region"
+    "connectionMethod"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1499,9 +1499,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "pino": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.4.tgz",
-      "integrity": "sha512-g4tHSISmQJYUEKEMVdaZ+ZokWwFnTwZL5JPn+lnBVZ1BuBbrSchrXwQINknkM5+Q4fF6U9NjiI8PWwwMDHt9zA==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
+      "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
       "requires": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.8",

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -2,9 +2,9 @@ import AbstractDriver from '@sqltools/base-driver';
 import { IConnectionDriver, MConnectionExplorer, NSDatabase, Arg0, ContextValue } from '@sqltools/types';
 import queries from './queries';
 import { v4 as generateId } from 'uuid';
-import { Athena } from 'aws-sdk';
+import { Athena, Credentials, SharedIniFileCredentials } from 'aws-sdk';
 
-export default class YourDriverClass extends AbstractDriver<Athena, Athena.Types.ClientConfiguration> implements IConnectionDriver {
+export default class AthenaDriver extends AbstractDriver<Athena, Athena.Types.ClientConfiguration> implements IConnectionDriver {
 
   queries = queries
 
@@ -31,11 +31,17 @@ export default class YourDriverClass extends AbstractDriver<Athena, Athena.Types
       return this.connection;
     }
 
-    this.connection = Promise.resolve(new Athena({
-      credentials: {
+    if (!this.credentials.profile)
+      var credentials = new Credentials({
         accessKeyId: this.credentials.accessKeyId,
         secretAccessKey: this.credentials.secretAccessKey,
-      },
+        sessionToken: this.credentials.sessionToken,
+      });
+    else
+      var credentials = new SharedIniFileCredentials({ profile: this.credentials.profile });
+
+    this.connection = Promise.resolve(new Athena({
+      credentials: credentials,
       region: this.credentials.region || 'us-east-1',
     }));
 

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -57,6 +57,7 @@ export default class AthenaDriver extends AbstractDriver<Athena, Athena.Types.Cl
 
     const queryExecution = await db.startQueryExecution({
       QueryString: query,
+      WorkGroup: this.credentials.workgroup
     }).promise();
 
     const endStatus = new Set(['FAILED', 'SUCCEEDED', 'CANCELLED']);

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -31,7 +31,7 @@ export default class AthenaDriver extends AbstractDriver<Athena, Athena.Types.Cl
       return this.connection;
     }
 
-    if (!this.credentials.profile)
+    if (this.credentials.connectionMethod !== 'Profile')
       var credentials = new Credentials({
         accessKeyId: this.credentials.accessKeyId,
         secretAccessKey: this.credentials.secretAccessKey,

--- a/src/ls/queries.ts
+++ b/src/ls/queries.ts
@@ -23,8 +23,8 @@ ORDER BY cid ASC
 const fetchRecords: IBaseQueries['fetchRecords'] = queryFactory`
 SELECT *
 FROM ${p => (p.table.label || p.table)}
-LIMIT ${p => p.limit || 50}
-OFFSET ${p => p.offset || 0};
+OFFSET ${p => p.offset || 0}
+LIMIT ${p => p.limit || 50};
 `;
 
 const countRecords: IBaseQueries['countRecords'] = queryFactory`


### PR DESCRIPTION
Provide capability to choose between authenticating with access key or with `~/.aws/credentials` profile.
I also noticed that workgroup wasn't getting passed in to the athena client when starting query execution.

Limit and Offset appeared to be in the wrong order. Not sure if it's just a configuration for my aws db or if it was just overlooked.
Thanks for a great base code to work with.