### PR TITLE
Add support for a credential provider process

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -16,7 +16,7 @@
       "title": "Connect using",
       "type": "string",
       "minLength": 1,
-      "enum": ["Profile", "Session Credentials"],
+      "enum": ["Profile", "Session Credentials", "Profile Credential Process"],
       "default": "Profile"
     },
     "outputLocation": {
@@ -30,7 +30,7 @@
         {
           "properties": {
             "connectionMethod": {
-              "enum": ["Profile"]
+              "enum": ["Profile", "Profile Credential Process"]
             },
             "profile": {
               "title": "AWS Profile",


### PR DESCRIPTION
This PR is adding support for getting AWS credentials from a provider process. The setup is very similar to the 'Profile' connection method currently implemented.