### PR TITLE
Enabled SSO Credentials

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -16,7 +16,7 @@
       "title": "Connect using",
       "type": "string",
       "minLength": 1,
-      "enum": ["Profile", "Session Credentials"],
+      "enum": ["Profile", "SSO Profile", "Session Credentials"],
       "default": "Profile"
     },
     "outputLocation": {
@@ -34,6 +34,21 @@
             },
             "profile": {
               "title": "AWS Profile",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "workgroup", "profile", "region"
+          ]
+        },
+        {
+          "properties": {
+            "connectionMethod": {
+              "enum": ["SSO Profile"]
+            },
+            "profile": {
+              "title": "AWS SSO Profile",
               "type": "string",
               "minLength": 1
             }


### PR DESCRIPTION
Added support for SSO AWS credentials through profiles, using SsoCredentials from the AWS-SDK.

Added the option SSO Profile:
![Screenshot 2024-05-30 at 17 37 47](https://github.com/kovihq/sqltools-athena-driver/assets/45567247/22ec6850-4640-476e-a5e7-e30ceb84bc72)

